### PR TITLE
Fixed the timestamp filter issue

### DIFF
--- a/phoenix-hive/pom.xml
+++ b/phoenix-hive/pom.xml
@@ -146,7 +146,7 @@
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-tests</artifactId>
       <scope>test</scope>
-      <version>0.9.1.3.0.3.0-SNAPSHOT</version>
+      <version>0.9.1.3.1.0.0-78</version>
       <type>test-jar</type>
       <exclusions>
         <exclusion>
@@ -159,7 +159,7 @@
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-dag</artifactId>
       <scope>test</scope>
-      <version>0.9.1.3.0.3.0-SNAPSHOT</version>
+      <version>0.9.1.3.1.0.0-78</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -24,10 +24,11 @@ import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
+import org.apache.commons.logging.LogFactory
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
     extends BaseRelation with PrunedFilteredScan {
-
+  val LOG = LogFactory.getLog(classOf[PhoenixRelation])
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
     Spark SQL queries with columns or predicates specified will be pushed down
@@ -105,6 +106,7 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
   // Helper function to escape string values in SQL queries
   private def compileValue(value: Any): Any = value match {
+
     case stringValue: String => s"'${escapeStringConstant(stringValue)}'"
 
     // Borrowed from 'elasticsearch-hadoop', support these internal UTF types across Spark versions
@@ -112,7 +114,10 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
     case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
     // Spark 1.5
     case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
-
+    case timestampValue: java.sql.Timestamp => {
+      s"to_timestamp('${timestampValue}')"
+    }
+    // Wrapping value in to_timestamp if
     // Pass through anything else
     case _ => value
   }

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -24,11 +24,9 @@ import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.SchemaUtil
-import org.apache.commons.logging.LogFactory
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
     extends BaseRelation with PrunedFilteredScan {
-  val LOG = LogFactory.getLog(classOf[PhoenixRelation])
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
     Spark SQL queries with columns or predicates specified will be pushed down
@@ -114,9 +112,8 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
     case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
     // Spark 1.5
     case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
-    case timestampValue: java.sql.Timestamp => {
-      s"to_timestamp('${timestampValue}')"
-    }
+    case timestampValue: java.sql.Timestamp => s"to_timestamp('${timestampValue}')"
+
     // Wrapping value in to_timestamp if
     // Pass through anything else
     case _ => value

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -17,16 +17,23 @@
  */
 package org.apache.phoenix.spark
 
+import java.sql.{Date, Timestamp}
+import java.text.Format
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.phoenix.util.StringUtil.escapeStringConstant
-import org.apache.phoenix.util.SchemaUtil
+import org.apache.phoenix.util.{DateUtil, SchemaUtil}
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
     extends BaseRelation with PrunedFilteredScan {
+
+  val dateformat:Format = DateUtil.getDateFormatter(DateUtil.DEFAULT_DATE_FORMAT)
+  val timeformat:Format = DateUtil.DEFAULT_TIMESTAMP_FORMATTER
+
   /*
     This is the buildScan() implementing Spark's PrunedFilteredScan.
     Spark SQL queries with columns or predicates specified will be pushed down
@@ -112,7 +119,9 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
     case utf if (isClass(utf, "org.apache.spark.sql.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
     // Spark 1.5
     case utf if (isClass(utf, "org.apache.spark.unsafe.types.UTF8String")) => s"'${escapeStringConstant(utf.toString)}'"
-    case timestampValue: java.sql.Timestamp => s"to_timestamp('${timestampValue}')"
+    case timestampValue: Timestamp => getTimestampString(timestampValue)
+
+    case dateValue: Date => getDateString(dateValue)
 
     // Wrapping value in to_timestamp if
     // Pass through anything else
@@ -121,5 +130,15 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
   private def isClass(obj: Any, className: String) = {
     className.equals(obj.getClass().getName())
+  }
+
+  private def getTimestampString(timestampValue: Timestamp): String = {
+    "TO_TIMESTAMP('%s', '%s', '%s')".format(timeformat.format(timestampValue),
+      DateUtil.DEFAULT_TIME_FORMAT, DateUtil.DEFAULT_TIME_ZONE_ID)
+  }
+
+  private def getDateString(dateValue: Date): String = {
+    "TO_DATE('%s', '%s', '%s')".format(dateformat.format(dateValue),
+      DateUtil.DEFAULT_DATE_FORMAT, DateUtil.DEFAULT_TIME_ZONE_ID)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -40,19 +40,28 @@
 
   <repositories>
     <repository>
-      <id>apache release</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>HDPReleases</id>
+      <name>HDP Releases</name>
+      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <layout>default</layout>
     </repository>
     <repository>
-      <id>hwx-public</id>
-      <name>hwx</name>
-      <url>http://nexus-private.hortonworks.com/nexus/content/groups/public/</url>
-			<releases>
-			  <enabled>true</enabled>
-			</releases>
-			<snapshots>
-			  <enabled>true</enabled>
-			</snapshots>
+      <id>public.repo.hortonworks.com</id>
+      <name>Public Hortonworks Maven Repo</name>
+      <url>http://repo.hortonworks.com/content/groups/public/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
I modified the fix based on the solution we have in latest connector https://github.com/apache/phoenix-connectors/blob/master/phoenix-spark/src/main/scala/org/apache/phoenix/spark/FilterExpressionCompiler.scala#L106-L128, so basically I port that code instead of wrapping within to_timestamp and both the fix work same way.

```
Original dataset
================

select count(*) from OBSERVED_ENTITY_RELATION_MINUTELY_COUNTS where tid ='BAT' and entityid = 'lalala' and dateminute <= to_date('2019-05-15 23:59:59.000');
+-----------+
| COUNT(1)  |
+-----------+
| 3690      |
+-----------+

select min(dateminute), max(dateminute) from OBSERVED_ENTITY_RELATION_MINUTELY_COUNTS where tid ='BAT' and entityid = 'lalala' and dateminute <= to_date('2019-05-15 23:59:59.000');
+--------------------------+--------------------------+
|     MIN(DATEMINUTE)      |     MAX(DATEMINUTE)      |
+--------------------------+--------------------------+
| 2019-05-15 15:29:00.000  | 2019-05-15 21:47:00.000  |
+--------------------------+--------------------------+


With timestamp fix port from V2 API code
========================================

select count(*) from OBSERVED_ENTITY_RELATION_MINUTELY_COUNTS where tid ='BA2' and entityid = 'lalala' and dateminute <= to_date('2019-05-15 23:59:59.000');
+-----------+
| COUNT(1)  |
+-----------+
| 3690      |
+-----------+

select min(dateminute), max(dateminute) from OBSERVED_ENTITY_RELATION_MINUTELY_COUNTS where tid ='BA2' and entityid = 'lalala' and dateminute <= to_date('2019-05-15 23:59:59.000');
+--------------------------+--------------------------+
|     MIN(DATEMINUTE)      |     MAX(DATEMINUTE)      |
+--------------------------+--------------------------+
| 2019-05-15 15:29:00.000  | 2019-05-15 21:47:00.000  |
+--------------------------+--------------------------+
```
the code which creates tenant BA1 by filtering BAT tenant
<img width="2295" alt="Screen Shot 2019-07-11 at 11 16 16 AM" src="https://user-images.githubusercontent.com/15984917/61063384-e3fad300-a3cd-11e9-976f-e3ec34b277ab.png">
