### PR TITLE
Fixed where clause order issue

### DIFF
--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -25,15 +25,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
-
-import org.apache.commons.logging.LogFactory;
 import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.{DateUtil, SchemaUtil}
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
     extends BaseRelation with PrunedFilteredScan {
 
-  val log = LogFactory.getLog("ESClient")
   val dateformat:Format = DateUtil.getDateFormatter(DateUtil.DEFAULT_DATE_FORMAT)
   val timeformat:Format = DateUtil.DEFAULT_TIMESTAMP_FORMATTER
 

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -25,12 +25,15 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources._
+
+import org.apache.commons.logging.LogFactory;
 import org.apache.phoenix.util.StringUtil.escapeStringConstant
 import org.apache.phoenix.util.{DateUtil, SchemaUtil}
 
 case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Boolean = false)(@transient val sqlContext: SQLContext)
     extends BaseRelation with PrunedFilteredScan {
 
+  val log = LogFactory.getLog("ESClient")
   val dateformat:Format = DateUtil.getDateFormatter(DateUtil.DEFAULT_DATE_FORMAT)
   val timeformat:Format = DateUtil.DEFAULT_TIMESTAMP_FORMATTER
 
@@ -69,6 +72,7 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
   // Attempt to create Phoenix-accepted WHERE clauses from Spark filters,
   // mostly inspired from Spark SQL JDBCRDD and the couchbase-spark-connector
   private def buildFilter(filters: Array[Filter]): String = {
+    
     if (filters.isEmpty) {
       return ""
     }
@@ -79,14 +83,14 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
     filters.foreach(f => {
       // Assume conjunction for multiple filters, unless otherwise specified
       if (i > 0) {
-        filter.append(" AND")
+        filter.append(" AND ")
       }
 
       f match {
         // Spark 1.3.1+ supported filters
-        case And(leftFilter, rightFilter) => filter.append(buildFilter(Array(leftFilter, rightFilter)))
-        case Or(leftFilter, rightFilter) => filter.append(buildFilter(Array(leftFilter)) + " OR " + buildFilter(Array(rightFilter)))
-        case Not(aFilter) => filter.append(" NOT " + buildFilter(Array(aFilter)))
+        case And(leftFilter, rightFilter) => filter.append("(" + buildFilter(Array(leftFilter, rightFilter)) + ")")
+        case Or(leftFilter, rightFilter) => filter.append("(" + buildFilter(Array(leftFilter)) + " OR " + buildFilter(Array(rightFilter)) + ")")
+        case Not(aFilter) => filter.append(" NOT " + "(" + buildFilter(Array(aFilter)) + ")")
         case EqualTo(attr, value) => filter.append(s" ${escapeKey(attr)} = ${compileValue(value)}")
         case GreaterThan(attr, value) => filter.append(s" ${escapeKey(attr)} > ${compileValue(value)}")
         case GreaterThanOrEqual(attr, value) => filter.append(s" ${escapeKey(attr)} >= ${compileValue(value)}")
@@ -102,7 +106,6 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
       i = i + 1
     })
-
     filter.toString()
   }
 


### PR DESCRIPTION
**ISSUE**

Phoenix drops the filter orders `between AND, OR and also around NOT` operator which cause the performance issue by reading more records than usual. 

![screenshot-1](https://user-images.githubusercontent.com/15984917/62314755-c0252d00-b461-11e9-95ea-a216cf395a0c.png)
 
https://filetrek.atlassian.net/browse/FT-18794?filter=-1


**Performance testing** 

Before this fix, 5.9.0 working days/hours took 9 minutes to complete on 94 million sensor records but with this fix now it takes 1-2 minutes to complete (as same as 5.7.1 runtime)

**Results Comparision testing**

Ran it on tenant CT5 and CT9 with and without this fix and anomaly counts and scoring per entity type and entityId matches.


